### PR TITLE
Fix an issue with empty text blocks.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@openwebwork/mathquill",
-	"version": "0.11.0-beta.2",
+	"version": "0.11.0-beta.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@openwebwork/mathquill",
-			"version": "0.11.0-beta.2",
+			"version": "0.11.0-beta.3",
 			"license": "MPL-2.0",
 			"devDependencies": {
 				"@awmottaz/prettier-plugin-void-html": "^1.6.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@openwebwork/mathquill",
 	"description": "Easily type math in your webapp",
-	"version": "0.11.0-beta.2",
+	"version": "0.11.0-beta.3",
 	"license": "MPL-2.0",
 	"repository": {
 		"type": "git",

--- a/src/commands/textElements.ts
+++ b/src/commands/textElements.ts
@@ -225,7 +225,11 @@ export class TextBlock extends BlockFocusBlur(deleteSelectTowardsMixin(TNode)) {
 		if (!cursor) return;
 		if (this.textContents() === '') {
 			this.remove();
-			if (cursor.left === this) cursor.left = this.left;
+			if (cursor.parent === this) {
+				cursor.parent = this.parent;
+				cursor.left = this.left;
+				cursor.right = this.right;
+			} else if (cursor.left === this) cursor.left = this.left;
 			else if (cursor.right === this) cursor.right = this.right;
 		} else {
 			// If the text block contains the selection, then that needs to be removed before fuseChildren is called.

--- a/src/services/focusBlur.ts
+++ b/src/services/focusBlur.ts
@@ -53,9 +53,13 @@ export const FocusBlurEvents = <TBase extends Constructor<ControllerBase>>(Base:
 						this.cursor.show();
 					}
 				} else {
-					this.cursor.hide().parent?.blur();
-					if (document.hasFocus()) this.cursor.clearSelection().endSelection();
-					else if (this.cursor.selection) this.cursor.selection.elements.addClass('mq-blur');
+					if (document.hasFocus()) {
+						this.cursor.hide().parent?.blur(this.cursor);
+						this.cursor.clearSelection().endSelection();
+					} else {
+						this.cursor.hide().parent?.blur();
+						if (this.cursor.selection) this.cursor.selection.elements.addClass('mq-blur');
+					}
 				}
 				this.updateMathspeak(true);
 			};


### PR DESCRIPTION
When focus is lost from the MathQuill input entirely and the cursor is inside an empty text block, then the text block is not removed as it should be.  Furthermore, if the text block is clicked on after that an exception is thrown.  This ensures the text block is removed in this case so that when focus returns the exception is not thrown.