### PR TITLE
Add `overflow: visible` to svgs used for brackets and such.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@openwebwork/mathquill",
-	"version": "0.11.0-beta.3",
+	"version": "0.11.0-beta.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@openwebwork/mathquill",
-			"version": "0.11.0-beta.3",
+			"version": "0.11.0-beta.4",
 			"license": "MPL-2.0",
 			"devDependencies": {
 				"@awmottaz/prettier-plugin-void-html": "^1.6.1",
@@ -4460,9 +4460,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001655",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001655.tgz",
-			"integrity": "sha512-jRGVy3iSGO5Uutn2owlb5gR6qsGngTw9ZTb4ali9f3glshcNmJ2noam4Mo9zia5P9Dk3jNNydy7vQjuE5dQmfg==",
+			"version": "1.0.30001697",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001697.tgz",
+			"integrity": "sha512-GwNPlWJin8E+d7Gxq96jxM6w0w+VFeyyXRsjU58emtkYqnbwHqXm5uT2uCmO0RQE9htWknOP4xtBlLmM/gWxvQ==",
 			"dev": true,
 			"funding": [
 				{

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@openwebwork/mathquill",
 	"description": "Easily type math in your webapp",
-	"version": "0.11.0-beta.3",
+	"version": "0.11.0-beta.4",
 	"license": "MPL-2.0",
 	"repository": {
 		"type": "git",

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -42,6 +42,7 @@
 		left: 0;
 		width: 100%;
 		height: 100%;
+		overflow: visible;
 	}
 
 	* {


### PR DESCRIPTION
At the default zoom level for me in both Firefox and Chrome the bottom of a brace or bracket is clipped.  If I increase or decrease the zoom level the clipping stops.  It also seems to usually only happen in the first MathQuill input on the page, and not the later ones.  Also, this does not happen with the MathQuill test pages.  It only happens in webwork2.  So this may have something to do with some Bootstrap css.

Here is a screen shot of what I am seeing:
![svg-clipping](https://github.com/user-attachments/assets/b2026d1c-9755-4917-a5fe-7798e91fadd0)

Adding `overflow: visible` prevents this.  I don't think there is ever a situation where these svgs should be clipped, so I don't think there is any downside to adding this.

Also run `npx update-browserslist-db@latest` because I am seeing warnings about that.