### PR TITLE
Remove all of the default autoOperatorNames.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@openwebwork/mathquill",
-	"version": "0.11.0-beta.4",
+	"version": "0.11.0-beta.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@openwebwork/mathquill",
-			"version": "0.11.0-beta.4",
+			"version": "0.11.0-beta.5",
 			"license": "MPL-2.0",
 			"devDependencies": {
 				"@awmottaz/prettier-plugin-void-html": "^1.6.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@openwebwork/mathquill",
 	"description": "Easily type math in your webapp",
-	"version": "0.11.0-beta.4",
+	"version": "0.11.0-beta.5",
 	"license": "MPL-2.0",
 	"repository": {
 		"type": "git",

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -1,6 +1,6 @@
 // Symbols for Basic Mathematics
 
-import { type Direction, noop, bindMixin, LatexCmds, CharCmds } from 'src/constants';
+import { type Direction, noop, bindMixin, LatexCmds, CharCmds, BuiltInOpNames } from 'src/constants';
 import { Options } from 'src/options';
 import type { Cursor } from 'src/cursor';
 import { Parser } from 'services/parser.util';
@@ -40,10 +40,8 @@ class OperatorName extends Symbol {
 	}
 }
 
-for (const fn in new Options().autoOperatorNames) {
-	if (fn !== '_maxLength') {
-		LatexCmds[fn] = OperatorName;
-	}
+for (const fn in BuiltInOpNames) {
+	LatexCmds[fn] = OperatorName;
 }
 
 LatexCmds.operatorname = class extends MathCommand {

--- a/src/options.ts
+++ b/src/options.ts
@@ -129,39 +129,7 @@ export class Options {
 	}
 
 	// The set of operator names that MathQuill auto-unitalicizes.
-	static #autoOperatorNames: NamesWLength = (() => {
-		const ops: NamesWLength = { _maxLength: 9 };
-
-		// Standard operators
-		for (const op of [
-			'arg',
-			'det',
-			'dim',
-			'gcd',
-			'hom',
-			'ker',
-			'lg',
-			'lim',
-			'max',
-			'min',
-			'sup',
-			'limsup',
-			'liminf',
-			'injlim',
-			'projlim',
-			'Pr'
-		]) {
-			ops[op] = 1;
-		}
-
-		// compat with some of the nonstandard LaTeX exported by MathQuill
-		// before #247. None of these are real LaTeX commands so, seems safe
-		for (const op of ['gcf', 'hcf', 'lcm', 'proj', 'span']) {
-			ops[op] = 1;
-		}
-
-		return ops;
-	})();
+	static #autoOperatorNames: NamesWLength = { _maxLength: 0 };
 	#_autoOperatorNames?: NamesWLength;
 	get autoOperatorNames(): NamesWLength {
 		return this.#_autoOperatorNames ?? Options.#autoOperatorNames;

--- a/test/typing.test.ts
+++ b/test/typing.test.ts
@@ -65,8 +65,10 @@ suite('typing with auto-replaces', function () {
 		});
 
 		test('auto-operator names', function () {
+			mq.options.addAutoOperatorNames('ker');
 			mq.typedText('\\ker^2');
 			assertLatex('\\ker^2');
+			mq.options.removeAutoOperatorNames('ker');
 		});
 
 		test('nonexistent LaTeX command', function () {


### PR DESCRIPTION
None of these are generally valid for answers in PG problem and having them conflicts with units and string answers.  So now there are no autoOperatorNames set by default (same as autoCommands).  They can still be added if desired, and will continue to function as before if added.

The LaTeX commands are now created from the `BuiltInOpNames` constant instead of constructing a new `Options` object and getting the default `autoOperatorNames` from there.  That should never have been done that way anyway, and was a hack that goes back to the upstream MathQuill code.

This addresses https://github.com/openwebwork/webwork2/issues/2203 and https://github.com/openwebwork/webwork2/issues/2681.