### PR TITLE
Add some more cases where parentheses are needed in text output.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@openwebwork/mathquill",
 	"description": "Easily type math in your webapp",
-	"version": "0.11.0",
+	"version": "0.11.1",
 	"license": "MPL-2.0",
 	"repository": {
 		"type": "git",

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -305,7 +305,7 @@ const FractionChooseCreateLeftOfMixin = <TBase extends Constructor<MathCommand>>
 				while (
 					leftward &&
 					!(
-						leftward instanceof BinaryOperator ||
+						(leftward instanceof BinaryOperator && !(leftward instanceof LatexCmds.factorial)) ||
 						('text' in LatexCmds && leftward instanceof LatexCmds.text) ||
 						leftward instanceof UpperLowerLimitCommand ||
 						leftward.ctrlSeq === '\\ ' ||

--- a/src/commands/mathElements.ts
+++ b/src/commands/mathElements.ts
@@ -716,11 +716,13 @@ export class Fraction extends MathCommand {
 			let numBlocks = 0;
 			let haveDigits = false;
 			let numPeriods = 0;
+			let newBlock = false;
 			this.ends[dir]?.eachChild((child: TNode) => {
 				if (child instanceof Digit) haveDigits = true;
 				if (child instanceof VanillaSymbol && child.ctrlSeq === '.') ++numPeriods;
 
 				if (
+					newBlock ||
 					!(
 						child instanceof Digit ||
 						(child instanceof VanillaSymbol && child.ctrlSeq === '.' && numPeriods < 2 && !numBlocks) ||
@@ -729,6 +731,11 @@ export class Fraction extends MathCommand {
 					)
 				)
 					++numBlocks;
+
+				// These are things that terminate a block.  Anything typed after them
+				// starts a new block and increments the block count above.
+				newBlock =
+					('factorial' in LatexCmds && child instanceof LatexCmds.factorial) || child instanceof SupSub;
 
 				if (
 					(haveDigits && numBlocks) ||
@@ -838,11 +845,13 @@ export const supSubText = (prefix: string, block?: TNode) => {
 	let numBlocks = 0;
 	let haveDigits = false;
 	let numPeriods = 0;
+	let newBlock = false;
 	block?.eachChild((child: TNode) => {
 		if (child instanceof Digit) haveDigits = true;
 		if (child instanceof VanillaSymbol && child.ctrlSeq === '.') ++numPeriods;
 
 		if (
+			newBlock ||
 			!(
 				child instanceof Digit ||
 				(child instanceof VanillaSymbol && child.ctrlSeq === '.' && numPeriods < 2 && !numBlocks) ||
@@ -850,6 +859,10 @@ export const supSubText = (prefix: string, block?: TNode) => {
 			)
 		)
 			++numBlocks;
+
+		// These are things that terminate a block.  Anything typed after them
+		// starts a new block and increments the block count above.
+		newBlock = 'factorial' in LatexCmds && child instanceof LatexCmds.factorial;
 
 		if (
 			(haveDigits && numBlocks) ||


### PR DESCRIPTION
Fractions need parentheses around the numerator or denominator if anything is after a factorial or a SupSub.  For example, 2/(3!4!) or 2/(2^2 3^2).

SupSubs need parentheses on the superscripts or subscripts if anything is after a factorial. For example, 2^(2!3!)

Also, a live fraction should be allowed to be typed after a factorial. For example, if 2! is typed and then the forward slash is typed it should result in the fraction with 2! in the numerator and the cursor in the denominator.  Currenlty the 2! is in front of the fraction and the cursor is in the numerator.

This fixes https://github.com/openwebwork/webwork2/issues/2821.